### PR TITLE
Correct the spelling of GitHub in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@
 
 How many stars I got yesterday? What is the total stars number I got right now? Or, did someone follow me these days?
 
-As a practice of developing osx/cocoa, I try to achieve the above needs in Gitee. Gitee is a status bar application in osx platform. It updates data from Github periodically. Now gitee supports:
+As a practice of developing osx/cocoa, I try to achieve the above needs in Gitee. Gitee is a status bar application in osx platform. It updates data from GitHub periodically. Now gitee supports:
 
 1. Show the number of total stars, followers and notifications on the status bar.  
   <img src="https://github.com/Nightonke/Gitee/blob/master/Pictures/status_bar.png" width="600">  
-2. Basic informations about Github, like avatar, contributions and so on.  
+2. Basic informations about GitHub, like avatar, contributions and so on.  
   <img src="https://github.com/Nightonke/Gitee/blob/master/Pictures/tab_profile.png" width="300">  
 3. A pie charts which shows the starzagers of your repositories. You can adjust the least minimum starzagers number in settings. Try to choose repository to open its homepage in browser.  
   <img src="https://github.com/Nightonke/Gitee/blob/master/Pictures/tab_pie_1.png" width="300">
@@ -20,9 +20,9 @@ As a practice of developing osx/cocoa, I try to achieve the above needs in Gitee
 4. A bar/line chart which shows the trends of your followers or starzagers of repositories. Selects the content of charts from pop-up button on the top. Also, you can change the the unit of time in the radio group. The bar/ line chart is drawn in wkwebview by [e-charts](https://github.com/ecomfe/echarts).  
   <img src="https://github.com/Nightonke/Gitee/blob/master/Pictures/tab_trend_1.png" width="300">
   <img src="https://github.com/Nightonke/Gitee/blob/master/Pictures/tab_trend_2.png" width="300">  
-5. A list of [trendings from Github](https://github.com/trending).  
+5. A list of [trendings from GitHub](https://github.com/trending).  
   <img src="https://github.com/Nightonke/Gitee/blob/master/Pictures/tab_trending.png" width="300">  
-6. Notifications from Github. Gitee updates your notifications every 10 minutes by default, and reminds you on desktop as a user-notification for each unread notification. You can mark a notification(or all notifications of a repository/you) as read, or unsubscribe notification thread in notifications tab.
+6. Notifications from GitHub. Gitee updates your notifications every 10 minutes by default, and reminds you on desktop as a user-notification for each unread notification. You can mark a notification(or all notifications of a repository/you) as read, or unsubscribe notification thread in notifications tab.
   <img src="https://github.com/Nightonke/Gitee/blob/master/Pictures/tab_notification.png" width="300">  
   <img src="https://github.com/Nightonke/Gitee/blob/master/Pictures/notification_1.png" width="300">
   <img src="https://github.com/Nightonke/Gitee/blob/master/Pictures/notification_2.png" width="300">  


### PR DESCRIPTION
This pull request corrects the spelling of **GitHub** 🤓
https://github.com

Created with [`readme-correct`](https://github.com/dkhamsing/readme-correct).
